### PR TITLE
try section to prevent stopping due to internet reconnection

### DIFF
--- a/plotly-raspi-stream.py
+++ b/plotly-raspi-stream.py
@@ -2,6 +2,7 @@ import plotly.plotly as py
 from plotly.graph_objs import Scatter, Layout, Figure
 import time
 import readadc
+import socket
 
 username = 'your_plotly_username'
 api_key = 'your_api_key'
@@ -41,7 +42,7 @@ while True:
         try:
             stream.write({'x': i, 'y': sensor_data})
         except socket.error:
-            stream.open
+            stream.open()
             stream.write({'x': i, 'y': sensor_data})           
         i += 1
         # delay between stream posts

--- a/plotly-raspi-stream.py
+++ b/plotly-raspi-stream.py
@@ -37,7 +37,12 @@ stream.open()
 #the main sensor reading loop
 while True:
         sensor_data = readadc.readadc(sensor_pin, readadc.PINS.SPICLK, readadc.PINS.SPIMOSI, readadc.PINS.SPIMISO, readadc.PINS.SPICS)
-        stream.write({'x': i, 'y': sensor_data})
+        # try section prevents stopping due to internet reconnection
+        try:
+            stream.write({'x': i, 'y': sensor_data})
+        except socket.error:
+            stream.open
+            stream.write({'x': i, 'y': sensor_data})           
         i += 1
         # delay between stream posts
         time.sleep(0.25)


### PR DESCRIPTION
Whenever the internet connection reconnects, the open stream to plot.ly breaks,
The added section reopens the stream to plot.ly if necessary. (Fixed typo)